### PR TITLE
Fix border-color property typo

### DIFF
--- a/src/mainWindow.py
+++ b/src/mainWindow.py
@@ -181,7 +181,7 @@ class Ui_MainWindow(object):
 "        }\n"
 "\n"
 " QScrollBar::handle:vertical {\n"
-"    border-colour: red;\n"
+"    border-color: red;\n"
 "    gridline-color: rgb(255, 255, 255);\n"
 " }\n"
 "\n"

--- a/src/mainWindow.ui
+++ b/src/mainWindow.ui
@@ -184,7 +184,7 @@ QScrollBar {
         }
 
  QScrollBar::handle:vertical {
-	border-colour: red;
+	border-color: red;
 	gridline-color: rgb(255, 255, 255);
  }
 


### PR DESCRIPTION
Qt uses the US spelling for color, fixed.