### PR TITLE
(ER Patch 1.12) Increase pause length before low stats confirmation

### DIFF
--- a/services/macro.py
+++ b/services/macro.py
@@ -502,7 +502,7 @@ class Macro:
             # Choosing equip.
             keys_list.append('e')
             if value['not_enough_stats']:
-                keys_list.append('pause50|e|pause200')
+                keys_list.append('pause300|e|pause200')
 
             # Quiting cell.
             keys_list.append('q|pause200')


### PR DESCRIPTION
Melina's Fingers was my one must-use tool when playing Elden Ring. One of my main uses was to use Grafted Blade Greatsword's AoW buff in low-level characters. In the recent patch of 1.12, I noticed that FromSoftware seems to implemented some kind of blocking delay for the input before we can press confirm the low stats popup. Upon testing, the increase to 300 was I believe the safest length out there.

I really appreciate this awesome tool 🙏

Due to the adjusted input speed in Elden Ring patch 1.12